### PR TITLE
Add build+test CI,`rustfmt.toml`, various minor fixes and formatting

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,22 @@
+name: Rust
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Build
+      run: cargo build --verbose
+    - name: Run tests
+      run: cargo test --verbose

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,4 +1,4 @@
-name: Rust
+name: rust
 
 on:
   push:
@@ -11,12 +11,11 @@ env:
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Build
       run: cargo build --verbose
     - name: Run tests
-      run: cargo test --verbose
+      run: cargo test --verbose --all-features

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+force_multiline_blocks=true
+imports_indent="Block"
+imports_layout="Vertical"

--- a/src/auth/auth.rs
+++ b/src/auth/auth.rs
@@ -5,10 +5,24 @@
 //!
 //! Note that this code is unaudited and not fit for production use.
 
-use alloy_primitives::{Address, FixedBytes};
-use alloy_sol_types::{sol, SolError};
-use core::{borrow::BorrowMut, marker::PhantomData};
-use stylus_sdk::{contract, evm, msg, prelude::*};
+use alloy_primitives::{
+    Address,
+    FixedBytes,
+};
+use alloy_sol_types::{
+    sol,
+    SolError,
+};
+use core::{
+    borrow::BorrowMut,
+    marker::PhantomData,
+};
+use stylus_sdk::{
+    contract,
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait AuthParams {}
 
@@ -71,7 +85,7 @@ impl<T: AuthParams> Auth<T> {
         let authority_given = Authority::new(authority);
         let status = authority_given.can_call(&mut *storage, user, target, sig)?;
 
-        return Ok(status);
+        Ok(status)
     }
 
     fn is_authorized<S: TopLevelStorage + BorrowMut<Self>>(
@@ -90,7 +104,7 @@ impl<T: AuthParams> Auth<T> {
 #[external]
 impl<T: AuthParams> Auth<T> {
     pub fn owner(&self) -> Result<Address> {
-        Ok(Address::from(self.owner.get()))
+        Ok(self.owner.get())
     }
 
     pub fn authority(&self) -> Result<Authority> {

--- a/src/auth/mod.rs
+++ b/src/auth/mod.rs
@@ -1,2 +1,3 @@
+#[allow(clippy::module_inception)]
 pub mod auth;
 pub mod owned;

--- a/src/auth/owned.rs
+++ b/src/auth/owned.rs
@@ -7,9 +7,16 @@
 
 use alloc::vec::Vec;
 use alloy_primitives::Address;
-use alloy_sol_types::{sol, SolError};
+use alloy_sol_types::{
+    sol,
+    SolError,
+};
 use core::marker::PhantomData;
-use stylus_sdk::{evm, msg, prelude::*};
+use stylus_sdk::{
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait OwnedParams {}
 

--- a/src/tokens/erc1155.rs
+++ b/src/tokens/erc1155.rs
@@ -8,11 +8,28 @@
 //!
 //! Note that this code is unaudited and not fit for production use.
 
-use alloc::{string::String, vec::Vec};
-use alloy_primitives::{Address, U256};
-use alloy_sol_types::{sol, SolError};
-use core::{borrow::BorrowMut, marker::PhantomData};
-use stylus_sdk::{abi::Bytes, evm, msg, prelude::*};
+use alloc::{
+    string::String,
+    vec::Vec,
+};
+use alloy_primitives::{
+    Address,
+    U256,
+};
+use alloy_sol_types::{
+    sol,
+    SolError,
+};
+use core::{
+    borrow::BorrowMut,
+    marker::PhantomData,
+};
+use stylus_sdk::{
+    abi::Bytes,
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait ERC1155Params {
     fn uri(id: U256) -> String;
@@ -100,10 +117,8 @@ impl<T: ERC1155Params> ERC1155<T> {
             if u32::from_be_bytes(received) != 0xf23a6e61 {
                 return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
             }
-        } else {
-            if to == Address::ZERO {
-                return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
-            }
+        } else if to == Address::ZERO {
+            return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
         }
 
         Ok(())
@@ -127,10 +142,8 @@ impl<T: ERC1155Params> ERC1155<T> {
             if u32::from_be_bytes(received) != 0xbc197c81 {
                 return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
             }
-        } else {
-            if to == Address::ZERO {
-                return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
-            }
+        } else if to == Address::ZERO {
+            return Err(ERC1155Error::UnsafeRecipient(UnsafeRecipient {}));
         }
 
         Ok(())
@@ -151,9 +164,9 @@ impl<T: ERC1155Params> ERC1155<T> {
         evm::log(TransferSingle {
             operator: msg::sender(),
             from: Address::ZERO,
-            to: to,
-            id: id,
-            amount: amount,
+            to,
+            id,
+            amount,
         });
 
         Self::call_receiver(storage, id, Address::ZERO, to, amount, data.0)?;
@@ -184,7 +197,7 @@ impl<T: ERC1155Params> ERC1155<T> {
         evm::log(TransferBatch {
             operator: msg::sender(),
             from: Address::ZERO,
-            to: to,
+            to,
             ids: ids.clone(),
             amounts: amounts.clone(),
         });
@@ -207,10 +220,10 @@ impl<T: ERC1155Params> ERC1155<T> {
 
         evm::log(TransferBatch {
             operator: msg::sender(),
-            from: from,
+            from,
             to: Address::ZERO,
-            ids: ids,
-            amounts: amounts,
+            ids,
+            amounts,
         });
 
         Ok(())
@@ -223,10 +236,10 @@ impl<T: ERC1155Params> ERC1155<T> {
 
         evm::log(TransferSingle {
             operator: msg::sender(),
-            from: from,
+            from,
             to: Address::ZERO,
-            id: id,
-            amount: amount,
+            id,
+            amount,
         });
 
         Ok(())
@@ -255,8 +268,8 @@ impl<T: ERC1155Params> ERC1155<T> {
 
         evm::log(ApprovalForAll {
             owner: msg::sender(),
-            operator: operator,
-            approved: approved,
+            operator,
+            approved,
         });
 
         Ok(())
@@ -290,10 +303,10 @@ impl<T: ERC1155Params> ERC1155<T> {
 
         evm::log(TransferSingle {
             operator: msg::sender(),
-            from: from,
-            to: to,
-            id: id,
-            amount: amount,
+            from,
+            to,
+            id,
+            amount,
         });
 
         Self::call_receiver(storage, id, from, to, amount, data.0)
@@ -336,8 +349,8 @@ impl<T: ERC1155Params> ERC1155<T> {
 
         evm::log(TransferBatch {
             operator: msg::sender(),
-            from: from,
-            to: to,
+            from,
+            to,
             ids: ids.clone(),
             amounts: amounts.clone(),
         });

--- a/src/tokens/erc20.rs
+++ b/src/tokens/erc20.rs
@@ -89,7 +89,7 @@ type Result<T, E = ERC20Error> = core::result::Result<T, E>;
 
 impl<T: ERC20Params> ERC20<T> {
     pub fn compute_domain_separator() -> Result<B256> {
-        let mut digest_input = [0u8; 32 + 32];
+        let mut digest_input = [0u8; 160];
         digest_input[0..32].copy_from_slice(&crypto::keccak("EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)".as_bytes())[..]);
         digest_input[32..64].copy_from_slice(&crypto::keccak(T::NAME.as_bytes())[..]);
         digest_input[64..96].copy_from_slice(&crypto::keccak("1".as_bytes())[..]);
@@ -228,7 +228,7 @@ impl<T: ERC20Params> ERC20<T> {
         let nonce = nonce_setter.get();
         nonce_setter.set(nonce + U256::from(1));
 
-        let mut struct_hash = [0u8; 32 + 32];
+        let mut struct_hash = [0u8; 192];
         struct_hash[0..32].copy_from_slice(&crypto::keccak(b"Permit(address owner,address spender,uint256 value,uint256 nonce,uint256 deadline)")[..]);
         struct_hash[32..64].copy_from_slice(&owner[..]);
         struct_hash[64..96].copy_from_slice(&spender[..]);

--- a/src/tokens/erc20.rs
+++ b/src/tokens/erc20.rs
@@ -8,13 +8,32 @@
 //!
 //! Note that this code is unaudited and not fit for production use.
 
-use alloc::{string::String, vec::Vec};
-use alloy_primitives::{address, Address, B256, U256};
-use alloy_sol_types::{sol, sol_data, SolError, SolType};
+use alloc::{
+    string::String,
+    vec::Vec,
+};
+use alloy_primitives::{
+    address,
+    Address,
+    B256,
+    U256,
+};
+use alloy_sol_types::{
+    sol,
+    sol_data,
+    SolError,
+    SolType,
+};
 use core::marker::PhantomData;
 use stylus_sdk::call::RawCall;
 use stylus_sdk::crypto;
-use stylus_sdk::{block, contract, evm, msg, prelude::*};
+use stylus_sdk::{
+    block,
+    contract,
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait ERC20Params {
     const NAME: &'static str;
@@ -89,8 +108,8 @@ impl<T: ERC20Params> ERC20<T> {
 
         evm::log(Transfer {
             from: Address::ZERO,
-            to: to,
-            amount: amount,
+            to,
+            amount,
         });
     }
 
@@ -102,9 +121,9 @@ impl<T: ERC20Params> ERC20<T> {
         self.total_supply.set(self.total_supply.get() - amount);
 
         evm::log(Transfer {
-            from: from,
+            from,
             to: Address::ZERO,
-            amount: amount,
+            amount,
         });
     }
 }
@@ -256,7 +275,7 @@ impl<T: ERC20Params> ERC20<T> {
 
     pub fn domain_separator(&mut self) -> Result<B256> {
         if block::chainid() == T::INITIAL_CHAIN_ID {
-            Ok(T::INITIAL_DOMAIN_SEPARATOR.into())
+            Ok(T::INITIAL_DOMAIN_SEPARATOR)
         } else {
             Ok(ERC20::<T>::compute_domain_separator()?)
         }

--- a/src/tokens/erc6909.rs
+++ b/src/tokens/erc6909.rs
@@ -9,10 +9,17 @@
 //! Note that this code is unaudited and not fit for production use.
 
 use alloc::vec::Vec;
-use alloy_primitives::{Address, U256};
+use alloy_primitives::{
+    Address,
+    U256,
+};
 use alloy_sol_types::sol;
 use core::marker::PhantomData;
-use stylus_sdk::{evm, msg, prelude::*};
+use stylus_sdk::{
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait ERC6909Params {}
 
@@ -61,8 +68,8 @@ impl<T: ERC6909Params> ERC6909<T> {
             caller: msg::sender(),
             from: Address::ZERO,
             to: receiver,
-            id: id,
-            amount: amount,
+            id,
+            amount,
         });
     }
 
@@ -79,8 +86,8 @@ impl<T: ERC6909Params> ERC6909<T> {
             caller: msg::sender(),
             from: sender,
             to: Address::ZERO,
-            id: id,
-            amount: amount,
+            id,
+            amount,
         });
     }
 }
@@ -100,8 +107,8 @@ impl<T: ERC6909Params> ERC6909<T> {
             caller: msg::sender(),
             from: msg::sender(),
             to: receiver,
-            id: id,
-            amount: amount,
+            id,
+            amount,
         });
 
         Ok(true)
@@ -136,8 +143,8 @@ impl<T: ERC6909Params> ERC6909<T> {
             caller: msg::sender(),
             from: sender,
             to: receiver,
-            id: id,
-            amount: amount,
+            id,
+            amount,
         });
 
         Ok(true)
@@ -151,9 +158,9 @@ impl<T: ERC6909Params> ERC6909<T> {
 
         evm::log(Approval {
             owner: msg::sender(),
-            spender: spender,
-            id: id,
-            amount: amount,
+            spender,
+            id,
+            amount,
         });
 
         Ok(true)
@@ -166,8 +173,8 @@ impl<T: ERC6909Params> ERC6909<T> {
 
         evm::log(OperatorSet {
             owner: msg::sender(),
-            operator: operator,
-            approved: approved,
+            operator,
+            approved,
         });
 
         Ok(true)

--- a/src/tokens/erc721.rs
+++ b/src/tokens/erc721.rs
@@ -8,11 +8,28 @@
 //!
 //! Note that this code is unaudited and not fit for production use.
 
-use alloc::{string::String, vec::Vec};
-use alloy_primitives::{Address, U256};
-use alloy_sol_types::{sol, SolError};
-use core::{borrow::BorrowMut, marker::PhantomData};
-use stylus_sdk::{abi::Bytes, evm, msg, prelude::*};
+use alloc::{
+    string::String,
+    vec::Vec,
+};
+use alloy_primitives::{
+    Address,
+    U256,
+};
+use alloy_sol_types::{
+    sol,
+    SolError,
+};
+use core::{
+    borrow::BorrowMut,
+    marker::PhantomData,
+};
+use stylus_sdk::{
+    abi::Bytes,
+    evm,
+    msg,
+    prelude::*,
+};
 
 pub trait ERC721Params {
     const NAME: &'static str;
@@ -135,8 +152,8 @@ impl<T: ERC721Params> ERC721<T> {
 
         evm::log(Transfer {
             from: Address::ZERO,
-            to: to,
-            id: id,
+            to,
+            id,
         });
 
         Ok(())
@@ -160,7 +177,7 @@ impl<T: ERC721Params> ERC721<T> {
         evm::log(Transfer {
             from: owner,
             to: Address::ZERO,
-            id: id,
+            id,
         });
 
         Ok(())
@@ -244,11 +261,7 @@ impl<T: ERC721Params> ERC721<T> {
 
         self.get_approved.setter(id).set(spender);
 
-        evm::log(Approval {
-            owner: owner,
-            spender: spender,
-            id: id,
-        });
+        evm::log(Approval { owner, spender, id });
 
         Ok(())
     }
@@ -260,8 +273,8 @@ impl<T: ERC721Params> ERC721<T> {
 
         evm::log(ApprovalForAll {
             owner: msg::sender(),
-            operator: operator,
-            approved: approved,
+            operator,
+            approved,
         });
 
         Ok(())
@@ -295,11 +308,7 @@ impl<T: ERC721Params> ERC721<T> {
 
         self.get_approved.delete(id);
 
-        evm::log(Transfer {
-            from: from,
-            to: to,
-            id: id,
-        });
+        evm::log(Transfer { from, to, id });
 
         Ok(())
     }

--- a/src/utils/bytes32address.rs
+++ b/src/utils/bytes32address.rs
@@ -5,7 +5,10 @@
 //!
 //! Note that this code is unaudited and not fit for production use.
 
-use alloy_primitives::{Address, FixedBytes};
+use alloy_primitives::{
+    Address,
+    FixedBytes,
+};
 use core::marker::PhantomData;
 use stylus_sdk::prelude::*;
 

--- a/src/utils/create3.rs
+++ b/src/utils/create3.rs
@@ -6,14 +6,26 @@
 //! Note that this code is unaudited and not fit for production use.
 
 use alloc::vec::Vec;
-use alloy_primitives::{Address, B256, U256};
-use alloy_sol_types::{sol, sol_data, SolError, SolType};
+use alloy_primitives::{
+    Address,
+    B256,
+    U256,
+};
+use alloy_sol_types::{
+    sol,
+    sol_data,
+    SolError,
+    SolType,
+};
 use core::marker::PhantomData;
 use stylus_sdk::call::RawCall;
 use stylus_sdk::contract;
 use stylus_sdk::crypto;
 use stylus_sdk::deploy::RawDeploy;
-use stylus_sdk::{evm, prelude::*};
+use stylus_sdk::{
+    evm,
+    prelude::*,
+};
 
 const KECCAK256_PROXY_CHILD_BYTECODE: [u8; 32] = [
     33, 195, 93, 190, 27, 52, 74, 36, 136, 207, 51, 33, 214, 206, 84, 47, 142, 159, 48, 85, 68,
@@ -63,14 +75,14 @@ impl<T: CREATE3Params> CREATE3<T> {
                 .map(|ret| sol_data::Address::decode_single(ret.as_slice(), false).unwrap())
                 .map_err(|_| CREATE3Error::InitilizationFailed(InitilizationFailed {}))?;
 
-            return Ok(deployed);
+            Ok(deployed)
         } else {
-            return Err(CREATE3Error::DeploymentFailed(DeploymentFailed {}));
+            Err(CREATE3Error::DeploymentFailed(DeploymentFailed {}))
         }
     }
 
     pub fn get_deployed(salt: B256) -> Result<Address> {
-        return Ok(Self::get_deployed_with_creator(salt, contract::address())?);
+        Self::get_deployed_with_creator(salt, contract::address())
     }
 
     pub fn get_deployed_with_creator(salt: B256, creator: Address) -> Result<Address> {
@@ -80,7 +92,7 @@ impl<T: CREATE3Params> CREATE3<T> {
         proxy_packed[21..53].copy_from_slice(&salt[..]);
         proxy_packed[53..85].copy_from_slice(&KECCAK256_PROXY_CHILD_BYTECODE[..]);
 
-        let proxy = Address::from_word(crypto::keccak(&proxy_packed));
+        let proxy = Address::from_word(crypto::keccak(proxy_packed));
 
         let mut packed = [0u8; 1 + 1 + 20 + 1];
         packed[0] = 0xd6;
@@ -88,7 +100,7 @@ impl<T: CREATE3Params> CREATE3<T> {
         packed[2..22].copy_from_slice(&proxy[..]);
         packed[22] = 0x01;
 
-        return Ok(Address::from_word(crypto::keccak(&packed)));
+        Ok(Address::from_word(crypto::keccak(packed)))
     }
 }
 


### PR DESCRIPTION
Adds a `rustfmt.toml` for use with `cargo +nightly fmt` to enforce a strict coding style.

I have also added a workflow for building and running unit tests.

Note: Unrelated to the PR but clippy produces a bunch of access out of bounds errors for the ERC20 impl. Probably something to be looked at. If not I recommend using `#[allow(clippy::out_of_bounds_indexing)]` to silence it.